### PR TITLE
Task 7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+export dkwig0=very_secure_password

--- a/authorization-service/pom.xml
+++ b/authorization-service/pom.xml
@@ -7,12 +7,14 @@
         <version>1.0</version>
     </parent>
 
-    <artifactId>product</artifactId>
+    <artifactId>authorization-service</artifactId>
     <packaging>jar</packaging>
 
-    <name>product</name>
+    <name>authorization-service</name>
+    <url>http://maven.apache.org</url>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>
@@ -25,65 +27,29 @@
         </dependency>
 
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>utils</artifactId>
-            <version>2.26.9</version>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-events</artifactId>
+            <version>3.11.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
             <version>1.2.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.11.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>dynamodb</artifactId>
+            <artifactId>utils</artifactId>
             <version>2.26.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <version>2.26.9</version>
-            <type>pom</type>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sns</artifactId>
-            <version>2.26.16</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.16.0</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.8.1</version>
+            <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -102,7 +68,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
-                    <finalName>product</finalName>
+                    <finalName>authorization</finalName>
                     <outputDirectory>../assets</outputDirectory>
                 </configuration>
                 <executions>

--- a/authorization-service/src/main/java/com/myorg/lambdas/BasicAuthorizerLambda.java
+++ b/authorization-service/src/main/java/com/myorg/lambdas/BasicAuthorizerLambda.java
@@ -1,0 +1,51 @@
+package com.myorg.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.IamPolicyResponse;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * @author Aliaksei Tsvirko
+ */
+public class BasicAuthorizerLambda implements RequestHandler<APIGatewayCustomAuthorizerEvent, IamPolicyResponse> {
+    @Override
+    public IamPolicyResponse handleRequest(APIGatewayCustomAuthorizerEvent request, Context context) {
+        context.getLogger().log(request.toString());
+
+        String authorizationHeaderValue = request.getAuthorizationToken();
+
+        if (StringUtils.isEmpty(authorizationHeaderValue)) {
+            throw new RuntimeException("Unauthorized.");
+        }
+
+        String authorizationToken = authorizationHeaderValue.split(" ")[1];
+        String credentials = new String(Base64.getDecoder().decode(authorizationToken));
+        String user = credentials.split("=")[0];
+        String password = credentials.split("=")[1];
+
+        if (StringUtils.equals(password, System.getenv(user))) {
+            return generatePolicy(user, IamPolicyResponse.ALLOW, request.getMethodArn());
+        }
+
+        return generatePolicy(user, IamPolicyResponse.DENY, request.getMethodArn());
+    }
+
+    private IamPolicyResponse generatePolicy(String principalId, String effect, String resource) {
+        return IamPolicyResponse.builder()
+                .withPrincipalId(principalId)
+                .withPolicyDocument(IamPolicyResponse.PolicyDocument.builder()
+                        .withVersion(IamPolicyResponse.VERSION_2012_10_17)
+                        .withStatement(List.of(IamPolicyResponse.Statement.builder()
+                                .withEffect(effect)
+                                .withAction(IamPolicyResponse.EXECUTE_API_INVOKE)
+                                .withResource(List.of(resource))
+                                .build()))
+                        .build())
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,5 +12,6 @@
         <module>product</module>
         <module>cdk</module>
         <module>import</module>
+        <module>authorization-service</module>
     </modules>
 </project>


### PR DESCRIPTION
- authorization-service is added to the repo, has correct basicAuthorizer lambda and correct AWS CDK Stack
- Import Service AWS CDK Stack has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser localStorage
- Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

[FE link](https://d1rh1cdtj16wwn.cloudfront.net/)
[FE PR link](https://github.com/dkwig0/nodejs-aws-shop-react/pull/5)
[Sample CSV](https://github.com/dkwig0/rs-app-be/blob/main/sample-products.csv)

200:
localStorage.setItem('authorization_token', "ZGt3aWcwOnZlcnlfc2VjdXJlX3Bhc3N3b3Jk");
401
localStorage.setItem('authorization_token', "");
403
localStorage.setItem('authorization_token', "V11GF0aS1Nb29uOlRFU1RfUEFTU1dPUkQ=");